### PR TITLE
Restore defaultuser group functionality (only used by adduser command)

### DIFF
--- a/src/core/master/src/main/java/org/drftpd/master/commands/usermanagement/UserManagementHandler.java
+++ b/src/core/master/src/main/java/org/drftpd/master/commands/usermanagement/UserManagementHandler.java
@@ -173,18 +173,18 @@ public class UserManagementHandler extends CommandInterface {
         Group g = null;
         if (isGAdduser) {
             g = session.getGroupNull(st.nextToken());
-        } else {
-            // regular adduser, take over primary group of user
-            g = currentUser.getGroup();
-        }
-
-        // If the group is unknown we bail out
-        if (g == null) {
-            throw new ImproperUsageException();
+            // Make sure the group actually exists...
+            if (g == null) {
+                return new CommandResponse(500, "Group does not exist");
+            }
         }
 
         // If the currentUser is a group admin check if he actually is the group admin for the group we are adding a user to and that there are enough slots available
         if (isGroupAdmin) {
+            if (!isGAdduser) {
+                // regular adduser, take over primary group of user
+                g = currentUser.getGroup();
+            }
             if (!g.isAdmin(currentUser)) {
                 return StandardCommandManager.genericResponse("RESPONSE_530_ACCESS_DENIED");
             }
@@ -216,6 +216,14 @@ public class UserManagementHandler extends CommandInterface {
             String wklyallotment = cfg.getProperty("wkly_allotment", "0");
             String credits = cfg.getProperty("credits", "0b");
             String tagline = cfg.getProperty("tagline", "No tagline set.");
+            String group = cfg.getProperty("group", "");
+            if (g == null) {
+                g = session.getGroupNull(group);
+                // Make sure the group actually exists...
+                if (g == null) {
+                    return new CommandResponse(500, "Defaultuser group does not exist");
+                }
+            }
 
             float ratioVal = Float.parseFloat(ratio);
             int maxloginsVal = Integer.parseInt(maxlogins);

--- a/src/core/master/src/main/java/org/drftpd/master/commands/usermanagement/UserManagementHandler.java
+++ b/src/core/master/src/main/java/org/drftpd/master/commands/usermanagement/UserManagementHandler.java
@@ -216,7 +216,8 @@ public class UserManagementHandler extends CommandInterface {
             String wklyallotment = cfg.getProperty("wkly_allotment", "0");
             String credits = cfg.getProperty("credits", "0b");
             String tagline = cfg.getProperty("tagline", "No tagline set.");
-            String group = cfg.getProperty("group", "");
+            String group = cfg.getProperty("group", "NoGroup");
+            // If we do not have a group yet we got here using 'adduser' and we pick the default group
             if (g == null) {
                 g = session.getGroupNull(group);
                 // Make sure the group actually exists...

--- a/src/core/master/src/main/resources/master/config/defaultgroup.conf.dist
+++ b/src/core/master/src/main/resources/master/config/defaultgroup.conf.dist
@@ -1,9 +1,8 @@
-############################
-## Default Group Settings ##
-####################################################################################################
+###########################################################
+## Default Group Settings, used when creating new groups ##
+###########################################################
 
 # min/max ratio that gadmins can set on their group members:
 # Default: [3.0][3.0]
 min_ratio=3.0
 max_ratio=3.0
-

--- a/src/core/master/src/main/resources/master/config/defaultuser.conf.dist
+++ b/src/core/master/src/main/resources/master/config/defaultuser.conf.dist
@@ -1,9 +1,43 @@
-###########################
-## Default User Settings ##
-###################################################################################################
+##########################################################
+## Default User Settings, used when creating a new user ##
+##########################################################
 
-# min/max ratio that gadmins can set on their group members:
-# Default: [3.0][3.0]
-min_ratio=3.0
-max_ratio=3.0
+# Ratio
+# Default: 3.0
+# ratio=3.0
 
+# Maximum logins
+# Default: 2
+# max_logins=2
+
+# Maximum logins per IP
+# Default: 2
+# max_logins_ip=2
+
+# Maximum uploads
+# Default: 2
+# max_uploads=2
+
+# Maximum downloads
+# Default: 2
+# max_downloads=2
+
+# Idle time
+# Default: 300
+# idle_time=300
+
+# Weekly allotment (0 = disabled)
+# Default: 0
+# wkly_allotment=0
+
+# Credits
+# Default: 0b
+# credits=0b
+
+# Tag line
+# Default: No tagline set.
+tagline=No tagline set.
+
+# Group
+# Default: NoGroup
+# group=NoGroup


### PR DESCRIPTION
We introduced a bug while we refactored the adding of users were the group could be inherited from 'defaultuser'.

This brings back that functionality and fixes #187