### PR TITLE
Enable runtime reload of log4j2 config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@
 .idea
 .dev
 target
-config
 build
 drftpd.key
+/config/
 
 site
 runtime

--- a/src/core/master/src/main/resources/master/config/log4j2-master.xml
+++ b/src/core/master/src/main/resources/master/config/log4j2-master.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration monitorInterval="30">
     <Properties>
         <Property name="baseDir">logs</Property>
     </Properties>

--- a/src/core/slave/src/main/resources/slave/config/log4j2-slave.xml
+++ b/src/core/slave/src/main/resources/slave/config/log4j2-slave.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration monitorInterval="30">
     <Properties>
         <Property name="baseDir">logs</Property>
     </Properties>


### PR DESCRIPTION
* Enable runtime reload of log4j2 config
* Fix config in .gitignore to only skip /config and not the path of the files i'm comitting here.

Easy to test:
* Start master with this new config
* Change loglevel of a entry to something more verbose like INFO or DEBUG
* tail log and you will see it the new loglevel starting to log

Closes #221