### PR TITLE
Fix building slave not overwriting resource files in output directory

### DIFF
--- a/src/core/slave/pom.xml
+++ b/src/core/slave/pom.xml
@@ -66,7 +66,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${maven.multiModuleProjectDirectory}/runtime/slave</outputDirectory>
-                            <overwite>true</overwite>
+                            <overwrite>true</overwrite>
                             <resources>
                                 <resource>
                                     <directory>src/main/resources/slave</directory>


### PR DESCRIPTION
Fix typo in slave POM copy-resources parameter name "overwite" to "overwrite".