### PR TITLE
Fix changing passcrypt mode accepts any password on first login

### DIFF
--- a/src/core/master/src/main/java/org/drftpd/master/usermanager/encryptedjavabeans/EncryptedBeanUser.java
+++ b/src/core/master/src/main/java/org/drftpd/master/usermanager/encryptedjavabeans/EncryptedBeanUser.java
@@ -222,7 +222,7 @@ public class EncryptedBeanUser extends BeanUser {
             }
         }
 
-        if (getEncryption() != _um.getPasscrypt()) {
+        if (result && (getEncryption() != _um.getPasscrypt())) {
             logger.debug("Converting Password To Current Encryption");
             setEncryption(0);
             this.setPassword(password);


### PR DESCRIPTION
When changing passcrypt mode (f.ex. from SHA-1 to bcrypt), the stored hash of a user's password is updated as part of the users first login after the mode change. However, the password is not verified to be correct before the stored hash is updated.
This PR adds the missing validation.