### PR TITLE
correct delgroup message

### DIFF
--- a/src/core/master/src/main/java/org/drftpd/master/commands/usermanagement/GroupManagementHandler.java
+++ b/src/core/master/src/main/java/org/drftpd/master/commands/usermanagement/GroupManagementHandler.java
@@ -148,7 +148,7 @@ public class GroupManagementHandler extends CommandInterface {
             }
 
             requestedGroup.purge();
-            response.addComment(session.jprintf(_bundle, "addgroup.success", env, request.getUser()));
+            response.addComment(session.jprintf(_bundle, "delgroup.success", env, request.getUser()));
             logger.info("'{}' purged '{}'", currentUser.getName(), requestedGroup.getName());
         } catch (GroupFileException e) {
             return new CommandResponse(452, e.getMessage());


### PR DESCRIPTION
Before:
```log
site delgroup TESTGROUP
200- Group TESTGROUP created.
200 Command okay
```

After:
```log
site delgroup TESTGROUP
200- Group TESTGROUP deleted.
200 Command okay
```