### PR TITLE
rename ZipscriptVFSDataSFV package to match path

### DIFF
--- a/src/plugins/autonuke/src/main/java/org/drftpd/autonuke/master/IncompleteConfig.java
+++ b/src/plugins/autonuke/src/main/java/org/drftpd/autonuke/master/IncompleteConfig.java
@@ -21,7 +21,7 @@ import org.drftpd.common.util.PropertyHelper;
 import org.drftpd.master.vfs.DirectoryHandle;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
 import org.drftpd.zipscript.common.zip.DizStatus;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 import org.drftpd.zipscript.master.zip.vfs.ZipscriptVFSDataZip;
 
 import java.util.Properties;

--- a/src/plugins/links/src/main/java/org/drftpd/links/master/types/sfvincomplete/SFVIncomplete.java
+++ b/src/plugins/links/src/main/java/org/drftpd/links/master/types/sfvincomplete/SFVIncomplete.java
@@ -21,7 +21,7 @@ import org.drftpd.links.master.LinkType;
 import org.drftpd.master.exceptions.NoAvailableSlaveException;
 import org.drftpd.master.exceptions.SlaveUnavailableException;
 import org.drftpd.master.vfs.DirectoryHandle;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/links/src/main/java/org/drftpd/links/master/types/sfvincomplete/SFVIncompleteManager.java
+++ b/src/plugins/links/src/main/java/org/drftpd/links/master/types/sfvincomplete/SFVIncompleteManager.java
@@ -29,9 +29,8 @@ import org.drftpd.master.event.ReloadEvent;
 import org.drftpd.master.event.TransferEvent;
 import org.drftpd.master.exceptions.NoAvailableSlaveException;
 import org.drftpd.master.exceptions.SlaveUnavailableException;
-import org.drftpd.master.usermanager.encryptedjavabeans.EncryptedBeanUserManager;
 import org.drftpd.master.vfs.event.VirtualFileSystemInodeDeletedEvent;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/raceleader/src/main/java/org/drftpd/raceleader/master/NewRaceLeaderHooks.java
+++ b/src/plugins/raceleader/src/main/java/org/drftpd/raceleader/master/NewRaceLeaderHooks.java
@@ -31,7 +31,7 @@ import org.drftpd.master.vfs.FileHandle;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
 import org.drftpd.zipscript.master.sfv.SFVTools;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/ZipscriptCommands.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/ZipscriptCommands.java
@@ -29,7 +29,7 @@ import org.drftpd.master.network.Session;
 import org.drftpd.master.usermanager.User;
 import org.drftpd.master.vfs.*;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 import org.drftpd.zipscript.master.zip.RescanPostProcessDirInterface;
 import org.reflections.Reflections;
 

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/SFVAnnouncer.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/SFVAnnouncer.java
@@ -45,6 +45,7 @@ import org.drftpd.master.vfs.InodeHandle;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
 import org.drftpd.zipscript.master.sfv.event.SFVMemberTransferEvent;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/SFVTools.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/SFVTools.java
@@ -25,6 +25,7 @@ import org.drftpd.master.vfs.FileHandle;
 import org.drftpd.master.vfs.VirtualFileSystem;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/event/SFVMemberTransferEvent.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/event/SFVMemberTransferEvent.java
@@ -23,7 +23,7 @@ import org.drftpd.master.slavemanagement.RemoteSlave;
 import org.drftpd.master.vfs.FileHandle;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.net.InetAddress;
 

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/hooks/ZipscriptPostHook.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/hooks/ZipscriptPostHook.java
@@ -47,8 +47,8 @@ import org.drftpd.master.vfs.FileHandle;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
 import org.drftpd.zipscript.master.sfv.SFVTools;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
 import org.drftpd.zipscript.master.sfv.event.SFVMemberTransferEvent;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/hooks/ZipscriptPreHook.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/hooks/ZipscriptPreHook.java
@@ -35,7 +35,7 @@ import org.drftpd.master.usermanager.User;
 import org.drftpd.master.vfs.DirectoryHandle;
 import org.drftpd.master.vfs.FileHandle;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/list/ZipscriptList.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/list/ZipscriptList.java
@@ -33,7 +33,7 @@ import org.drftpd.master.vfs.VirtualFileSystem;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
 import org.drftpd.zipscript.master.sfv.SFVTools;
-import org.drftpd.zipscript.master.sfv.ZipscriptVFSDataSFV;
+import org.drftpd.zipscript.master.sfv.vfs.ZipscriptVFSDataSFV;
 import org.reflections.Reflections;
 
 import java.io.FileNotFoundException;

--- a/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/vfs/ZipscriptVFSDataSFV.java
+++ b/src/plugins/zipscript/zipscript-master/src/main/java/org/drftpd/zipscript/master/sfv/vfs/ZipscriptVFSDataSFV.java
@@ -15,7 +15,7 @@
  * along with DrFTPD; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.drftpd.zipscript.master.sfv;
+package org.drftpd.zipscript.master.sfv.vfs;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,6 +31,8 @@ import org.drftpd.master.vfs.ObjectNotValidException;
 import org.drftpd.zipscript.common.sfv.AsyncResponseSFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVInfo;
 import org.drftpd.zipscript.common.sfv.SFVStatus;
+import org.drftpd.zipscript.master.sfv.SFVTools;
+import org.drftpd.zipscript.master.sfv.ZipscriptIssuer;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;


### PR DESCRIPTION
My IDE was lighting up red that this did not match, we seem to already have this structure for ZIP so this commit renames the SFV one to match the FS path.