### PR TITLE
Unify remerge handling of I/O errors

### DIFF
--- a/src/core/slave/src/main/java/org/drftpd/slave/vfs/RootCollection.java
+++ b/src/core/slave/src/main/java/org/drftpd/slave/vfs/RootCollection.java
@@ -160,8 +160,9 @@ public class RootCollection {
         } else {
             for (int i = 0; i < _roots.size(); i++) {
                 File rootPath = _roots.get(i).getFile(path);
-                if (rootPath.exists()) {
-                    files.addAll(Arrays.asList(rootPath.list()));
+                String[] rootFiles = rootPath.list();
+                if (rootFiles != null) {
+                    files.addAll(Arrays.asList(rootFiles));
                 }
             }
         }


### PR DESCRIPTION
The non-concurrent (serialized) code path in RootCollection getLocalInodes throw a null pointer exception on directories without read permissions.

The concurrent code path compares the result of File.list() to null to check for errors. The non-concurrent (serialized) code path does not check the return value, instead it calls File.exists() on the returned object.

File.list() returns an empty array when the directory is empty, and null on errors. Use the same logic in the non-concurrent code path, so the behaviour of the two code paths are the same.