### PR TITLE
Terminate Slave with an exit code similar to Master

### DIFF
--- a/src/core/slave/src/main/java/org/drftpd/slave/protocol/SlaveProtocolCentral.java
+++ b/src/core/slave/src/main/java/org/drftpd/slave/protocol/SlaveProtocolCentral.java
@@ -180,11 +180,10 @@ public class SlaveProtocolCentral {
         AsyncResponse ar;
 
         try {
-            logger.debug("Invoking {}", m);
+            logger.debug("Invoking {} with parameters {}", m.toGenericString(), ac.toString());
             ar = (AsyncResponse) m.invoke(ah, new Object[]{ac});
         } catch (Exception e) {
-            logger.error("Unable to invoke: {}", m.toGenericString(), e);
-            logger.error("Invokation for {} failed due to: {}", m.toGenericString(), e.getCause());
+            logger.error("Invokation for {} failed due to: {}", m.toGenericString(), e.getCause(), e);
             return new AsyncResponseException(ac.getIndex(), new Exception("Unable to invoke the proper handler", e));
         }
 


### PR DESCRIPTION
Terminate Slave with an exit code similar to Master, so Slave can be conditionally restarted.

Improve log messages when Slave handleCommand throws an exception.