### PR TITLE
Refactor ZipscriptMP3Handler and add JUnit test for invalid MP3s

### DIFF
--- a/src/plugins/zipscript/zipscript-slave/src/main/java/org/drftpd/zipscript/slave/mp3/ZipscriptMP3Handler.java
+++ b/src/plugins/zipscript/zipscript-slave/src/main/java/org/drftpd/zipscript/slave/mp3/ZipscriptMP3Handler.java
@@ -56,7 +56,13 @@ public class ZipscriptMP3Handler extends AbstractHandler {
 
     private MP3Info getMP3File(Slave slave, String path) throws IOException {
         MP3Parser mp3parser = new MP3Parser(slave.getRoots().getFile(path));
-        MP3Info mp3info = mp3parser.getMP3Info();
-        return mp3info;
+        try {
+            return mp3parser.getMP3Info();
+        } catch (IOException e) {
+            if (e.getMessage() != null && e.getMessage().endsWith("is not a valid MP3 file")) {
+                return null;
+            }
+            throw e;
+        }
     }
 }

--- a/src/plugins/zipscript/zipscript-slave/src/main/java/org/drftpd/zipscript/slave/mp3/ZipscriptMP3Handler.java
+++ b/src/plugins/zipscript/zipscript-slave/src/main/java/org/drftpd/zipscript/slave/mp3/ZipscriptMP3Handler.java
@@ -54,8 +54,12 @@ public class ZipscriptMP3Handler extends AbstractHandler {
         }
     }
 
-    private MP3Info getMP3File(Slave slave, String path) throws IOException {
-        MP3Parser mp3parser = new MP3Parser(slave.getRoots().getFile(path));
+    MP3Info getMP3File(Slave slave, String path) throws IOException {
+        return getMP3InfoFromFile(slave.getRoots().getFile(path));
+    }
+
+    MP3Info getMP3InfoFromFile(java.io.File file) throws IOException {
+        MP3Parser mp3parser = new MP3Parser(file);
         try {
             return mp3parser.getMP3Info();
         } catch (IOException e) {

--- a/src/plugins/zipscript/zipscript-slave/src/test/java/org/drftpd/zipscript/slave/mp3/ZipscriptMP3HandlerTest.java
+++ b/src/plugins/zipscript/zipscript-slave/src/test/java/org/drftpd/zipscript/slave/mp3/ZipscriptMP3HandlerTest.java
@@ -1,0 +1,31 @@
+package org.drftpd.zipscript.slave.mp3;
+
+import org.drftpd.zipscript.common.mp3.MP3Info;
+import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ZipscriptMP3HandlerTest {
+
+    @Test
+    public void testInvalidMP3ReturnsNull() throws IOException {
+        // Create a temporary file that is definitely not an MP3
+        File tempFile = File.createTempFile("test-invalid", ".mp3");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("This is not an MP3 file content.");
+        }
+        tempFile.deleteOnExit();
+
+        // Create instance of handler (we can pass null for central since we are testing
+        // isolated method)
+        ZipscriptMP3Handler handler = new ZipscriptMP3Handler(null);
+
+        // Call the package-private method with the file
+        MP3Info result = handler.getMP3InfoFromFile(tempFile);
+
+        // Verify it returns null instead of throwing IOException
+        assertNull(result, "Should return null for invalid MP3 file");
+    }
+}


### PR DESCRIPTION
## Problem
When encountering an invalid MP3 file, the slave would throw an IOException with message "X is not a valid MP3 file", causing errors in the async command handler.

## Solution
Catch the specific IOException in `ZipscriptMP3Handler.getMP3File()` and return null instead of propagating the exception. This allows graceful handling of invalid MP3 files.

## Changes Made
- Modified `ZipscriptMP3Handler.java` to catch IOException when parsing MP3 files
- If the error message indicates an invalid MP3 file, return null instead of throwing
- Other IOExceptions are still propagated

Fixes: #77 