### PR TITLE
Fix maven-dependency-plugin execution errors

### DIFF
--- a/src/core/common/pom.xml
+++ b/src/core/common/pom.xml
@@ -29,6 +29,7 @@
                         </goals>
                         <configuration>
                             <excludeScope>provided</excludeScope>
+                            <excludeGroupIds>${project.groupId}</excludeGroupIds>
                             <outputDirectory>${session.executionRootDirectory}/runtime/master/lib</outputDirectory>
                         </configuration>
                     </execution>
@@ -40,6 +41,7 @@
                         </goals>
                         <configuration>
                             <excludeScope>provided</excludeScope>
+                            <excludeGroupIds>${project.groupId}</excludeGroupIds>
                             <outputDirectory>${session.executionRootDirectory}/runtime/slave/lib</outputDirectory>
                         </configuration>
                     </execution>

--- a/src/core/master/pom.xml
+++ b/src/core/master/pom.xml
@@ -29,25 +29,28 @@
                         </goals>
                         <configuration>
                             <excludeScope>provided</excludeScope>
+                            <excludeGroupIds>${project.groupId}</excludeGroupIds>
                             <outputDirectory>${session.executionRootDirectory}/runtime/master/lib</outputDirectory>
                         </configuration>
                     </execution>
+            </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
                     <execution>
-                        <id>copy-generated</id>
+                        <id>copy-jar</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>copy</goal>
+                            <goal>run</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${session.executionRootDirectory}/runtime/master/build</outputDirectory>
+                            <target>
+                                <copy file="${project.build.directory}/${project.build.finalName}.jar" 
+                                      todir="${session.executionRootDirectory}/runtime/master/build" 
+                                      failonerror="true" verbose="true"/>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/core/slave/pom.xml
+++ b/src/core/slave/pom.xml
@@ -29,25 +29,28 @@
                         </goals>
                         <configuration>
                             <excludeScope>provided</excludeScope>
+                            <excludeGroupIds>${project.groupId}</excludeGroupIds>
                             <outputDirectory>${session.executionRootDirectory}/runtime/slave/lib</outputDirectory>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
                     <execution>
-                        <id>copy-generated</id>
+                        <id>copy-jar</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>copy</goal>
+                            <goal>run</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${session.executionRootDirectory}/runtime/slave/build</outputDirectory>
+                            <target>
+                                <copy file="${project.build.directory}/${project.build.finalName}.jar" 
+                                      todir="${session.executionRootDirectory}/runtime/slave/build" 
+                                      failonerror="true" verbose="true"/>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/plugins/pom.xml
+++ b/src/plugins/pom.xml
@@ -58,6 +58,7 @@
                         </goals>
                         <configuration>
                             <excludeScope>provided</excludeScope>
+                            <excludeGroupIds>${project.groupId}</excludeGroupIds>
                             <outputDirectory>${session.executionRootDirectory}/runtime/master/lib</outputDirectory>
                         </configuration>
                     </execution>
@@ -69,6 +70,7 @@
                         </goals>
                         <configuration>
                             <excludeScope>provided</excludeScope>
+                            <excludeGroupIds>${project.groupId}</excludeGroupIds>
                             <outputDirectory>${session.executionRootDirectory}/runtime/slave/lib</outputDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
- Exclude reactor artifacts from 'copy-dependencies' to prevent build failures when artifacts are not yet packaged.
- Replace 'copy-generated' execution with 'maven-antrun-plugin' to reliably copy built JARs from the target directory.